### PR TITLE
Fix paginate error by adding paginate plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,8 @@ paginate_path: "page:num"
 # https://github.com/mojombo/jekyll/wiki/Permalinks
 permalink:   /:categories/:title
 
+plugins: [jekyll-paginate]
+
 kramdown:
   auto_ids: true
   footnote_nr: 1


### PR DESCRIPTION
Hi, I really like your jekyll layout!
It seems there's an error that the paginate plugin is required to be specified in the _config.yml now, so I've added it.